### PR TITLE
handle 'None' as result of e.string if text node is not the only child

### DIFF
--- a/dictcc/dictcc.py
+++ b/dictcc/dictcc.py
@@ -107,7 +107,7 @@ class Dict(object):
                 to_lang=languages[1],
                 translation_tuples=zip(
                     [" ".join(map(lambda e: " ".join(e.strings), r)) for r in translations[0:-1:2]],
-                    [" ".join(map(lambda e: e.string, r)) for r in translations[1:-1:2]]
+                    [" ".join(map(lambda e: e.string if e.string else "".join(e.strings), r)) for r in translations[1:-1:2]]
                 ),
             )
 


### PR DESCRIPTION
happens e.g. if text of html tag contains text in `<b>` tags and outside:
`<a href="//www.dict.cc/deutsch-englisch/&lt;b&gt;Full&lt;/b&gt;-Custom-Entwurf.html"><b>Full</b>-Custom-Entwurf</a>`

Searching for "full name"