### PR TITLE
Add meta info to results, such as noun gender.

### DIFF
--- a/dictcc/dictcc.py
+++ b/dictcc/dictcc.py
@@ -82,7 +82,7 @@ class Dict(object):
                 ),
             )
 
-        translations = [tds.find_all("a") for tds in soup.find_all("td", class_="td7nl", attrs={'dir': "ltr"})]
+        translations = [tds.find_all(["a", "var"]) for tds in soup.find_all("td", class_="td7nl", attrs={'dir': "ltr"})]
         if len(translations) >= 2:
             languages = [next(lang.strings) for lang in soup.find_all("td", class_="td2", attrs={'dir': "ltr"})]
             if len(languages) != 2:


### PR DESCRIPTION
Additional information is contained in `<var>` tags on the same level as the `<a>` that contains the translation.
This additional information such as part of speech or gender of nouns is essential to the translation and usage of the words.