### PR TITLE
Colorize output

### DIFF
--- a/scripts/dict.cc.py
+++ b/scripts/dict.cc.py
@@ -2,9 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import re
+import colorama as clr
 
 from dictcc import Dict, AVAILABLE_LANGUAGES
 
+clr.init(autoreset=True)
 
 LINE_LENGTH = 60
 
@@ -13,6 +16,21 @@ def ensure_unicode(string):
     if hasattr(string, "decode"):
         return string.decode("utf-8")
     return string
+
+
+def str2bool(v):
+    """
+    Used to parse binary flag args
+    Copy-paste from stack overflow
+    """
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
 
 
 def parse_args():
@@ -29,6 +47,8 @@ def parse_args():
                                "phrases like \"free beer\")."))
     parser.add_argument("--max-results", "-n", type=int, default=10,
                         help="Number of results to display. -1 for no limit.")
+    parser.add_argument("--color", "-c", type=str2bool, default=True,
+                        help="Use color in output.")
     args = parser.parse_args()
 
     if args.input_language == args.output_language:
@@ -48,11 +68,37 @@ def print_header(from_lang, to_lang):
     ))
 
 
-def print_translation(input_word, output_word):
-    # Two points less for the spaces, so tables don't break
-    print(u"{} {} {}".format(input_word,
-                          "."*(LINE_LENGTH-len(input_word)-2),
-                          output_word))
+def print_translation(input_word, output_word, do_color, search_phrase):
+    def apply_color(string):
+        if do_color:
+            # Apply color codes to string for meta data and searched word
+
+            # Meta data is found within square or curly brackets
+            # First replace square brackets as the color codes themselves
+            # contain square brackets which should not be replaced
+            string = string.replace("[", clr.Fore.BLUE + "[")\
+                            .replace("]", "]" + clr.Fore.RESET)
+            string = string.replace("{", clr.Fore.BLUE + "{")\
+                            .replace("}", "}" + clr.Fore.RESET)
+
+            # Colorize words in search_phrase
+            # 1.Remove non alphabet characters from search_phrase
+            # 2.Split on spaces.
+            # 3.Match words in search_phrase as whole words only, ignore case
+            # NB. if the word is within brackets colorization will be inacurate
+            for wrd in re.sub('[^\w] ', '', search_phrase).split(" "):
+                string = re.sub(r"\b({})\b".format(re.escape(wrd)),
+                            clr.Fore.GREEN + r"\1" + clr.Fore.RESET,
+                            string,
+                            flags=re.IGNORECASE)
+        return string
+
+    # Three points less for the spaces and one point less for the equal sign,
+    # so tables don't break
+    padding_len = LINE_LENGTH-len(input_word)-4
+    print(u"{} {} = {}".format(apply_color(input_word),
+                                "."*padding_len,
+                                apply_color(output_word)))
 
 
 
@@ -74,7 +120,7 @@ def run():
     print_header(result.from_lang, result.to_lang)
 
     for i, (input_word, output_word) in enumerate(result.translation_tuples):
-        print_translation(input_word, output_word)
+        print_translation(input_word, output_word, args.color, args.word)
         if i == args.max_results:
             break
 

--- a/scripts/dict.cc.py
+++ b/scripts/dict.cc.py
@@ -27,7 +27,8 @@ def parse_args():
                          type=ensure_unicode,
                          help=("Word to translate (use quotation marks for "
                                "phrases like \"free beer\")."))
-    parser.add_argument("--max-results", type=int, default=10)
+    parser.add_argument("--max-results", "-n", type=int, default=10,
+                        help="Number of results to display. -1 for no limit.")
     args = parser.parse_args()
 
     if args.input_language == args.output_language:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
       description="Unofficial dict.cc command line interface",
       version="3.0.0",
       url="https://github.com/rbaron/dict.cc.py",
-      install_requires=["beautifulsoup4","requests"],
+      install_requires=["beautifulsoup4","requests","colorama"],
       packages=find_packages(),
       scripts=["scripts/dict.cc.py"]
      )


### PR DESCRIPTION
Add --color arg (default true) to apply colors to output using colorama.
Color individual words from searched phrase in green.
Color words in brackets in blue.
TODO: Handle nested colored words properly. Rare.
Add an equal sign (=) between translations as a separator to better
separate results that are too long to fit into the table alignment
(no dots are displayed or even wrap over to next line)