### PR TITLE
Fixed bug with display order of translation.tuples

### DIFF
--- a/dictcc/dictcc.py
+++ b/dictcc/dictcc.py
@@ -108,11 +108,15 @@ class Dict(object):
 
         [from_words, to_words] = zip(*result.translation_tuples)
 
-        return result if from_words.count(word) >= to_words.count(word) \
+        occurences = {"from_lang": 0, "to_lang": 0}
+        for [from_word, to_word] in result.translation_tuples:
+            occurences["from_lang"] = occurences["from_lang"] + 1 if from_word.lower().count(word.lower()) else occurences["from_lang"]
+            occurences["to_lang"] = occurences["to_lang"] + 1 if to_word.lower().count(word.lower()) else occurences["to_lang"]
+
+        return result if occurences["from_lang"] >= occurences["to_lang"] \
                       else Result(
                           from_lang=result.to_lang,
                           to_lang=result.from_lang,
                           translation_tuples=zip(to_words, from_words),
                       )
-
 

--- a/dictcc/dictcc.py
+++ b/dictcc/dictcc.py
@@ -108,12 +108,10 @@ class Dict(object):
 
         [from_words, to_words] = zip(*result.translation_tuples)
 
-        occurences = {"from_lang": 0, "to_lang": 0}
-        for [from_word, to_word] in result.translation_tuples:
-            occurences["from_lang"] = occurences["from_lang"] + 1 if from_word.lower().count(word.lower()) else occurences["from_lang"]
-            occurences["to_lang"] = occurences["to_lang"] + 1 if to_word.lower().count(word.lower()) else occurences["to_lang"]
+        n_from_lang = sum(from_word.lower().count(word.lower()) for from_word in from_words)
+        n_to_lang = sum(to_word.lower().count(word.lower()) for to_word in to_words)
 
-        return result if occurences["from_lang"] >= occurences["to_lang"] \
+        return result if n_from_lang >= n_to_lang \
                       else Result(
                           from_lang=result.to_lang,
                           to_lang=result.from_lang,


### PR DESCRIPTION
There was a bug that showed up whenever there was a slight discrepancy (e.g. punctuation marks or differences in capitalization) between the original word (to-be-translated) and its representation on the website. For instance, say "Entschuldigung" and "Entschuldigung!" or "entschuldigung" and "Entschuldigung." This code edit fixes it up by changing the mean of counting instances of the word in each side of the tuple. It creates a new dictionary "occurrences" to hold these values, which are later used to replace the original counting variables.