### PR TITLE
Added support for Norwegian (Bokmål)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ body [society, organisation for sth.] ..................... Gesellschaft [Organi
 
 ```
 
-Available languages include: `en`, `de`, `sv`, `pt`, `it`, `fr`, `ro`, `nl`.
+Available languages include: `en`, `de`, `sv`, `pt`, `it`, `fr`, `ro`, `nl`, `no`.
 
 Usage as Code
 ------------

--- a/dictcc/dictcc.py
+++ b/dictcc/dictcc.py
@@ -13,6 +13,7 @@ AVAILABLE_LANGUAGES = {
     "de": "german",
     "fr": "french",
     "sv": "swedish",
+    "no": "norwegian (bokmål)",
     "es": "spanish",
     "nl": "dutch",
     "bg": "bulgarian",


### PR DESCRIPTION
Trivial patch to add Norwegian (båkmal).

N.B. The `ISO 639-1 code` for bokmål is actually `nb` but dict.cc chose `no` as ID of that language. I complied to be consistent with that and keep this PR trivial.